### PR TITLE
Update extend to work continuously

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "washi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "One of many backbone-esque view helpers.",
   "main": "washi.js",
   "directories": {

--- a/test/washi-test.js
+++ b/test/washi-test.js
@@ -1,5 +1,12 @@
 describe("Washi", function() {
 
+	it ('can be extended multiple times', function() {
+		var w = new (Washi.extend({ head: 'head' }).extend({ tail: 'tail' }));
+
+		w.head.should.equal('head');
+		w.tail.should.equal('tail');
+	});
+
 	describe("Selection", function() {
 		var el = document.createElement("p");
 

--- a/washi.js
+++ b/washi.js
@@ -24,13 +24,14 @@
 	};
 
 	Washi.extend = function(options) {
+		var Parent = this;
 		var Child = function(options) {
-			Washi.apply(this, arguments);
+			Parent.apply(this, arguments);
 		};
 
-		Child.extend = Washi.extend;
+		Child.extend = Parent.extend;
 
-		$.extend(Child.prototype, Washi.prototype, options);
+		$.extend(Child.prototype, Parent.prototype, options);
 
 		return Child;
 	};


### PR DESCRIPTION
Adds support for `Washi.extend(obj).extend(obj).extend(....)`
